### PR TITLE
add metadataGroupOrder option, make examples interactive

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -16,36 +16,46 @@
     <script src="js/extensions.js"></script>
 </head>
 <body>
-    
+    <div class="testFixtureSelection">
+        <button class="testFixture" data-json="http://wellcomelibrary.org/iiif/b18035978/manifest">Manifest metadata</button>
+        <button class="testFixture" data-json="https://iiif.riksarkivet.se/arkis!C0000263/manifest">Canvas metadata</button>
+        <button class="testFixture" data-json="https://iiif.riksarkivet.se/arkis!F0001185/manifest">Merge source reference</button>
+        <button class="testFixture" data-json="https://edsilv.github.io/test-manifests/all-metadata.json">All metadata</button>
+        <button class="testFixture" data-json="http://tomcrane.github.io/scratch/manifests/vdc_100000004987.0x000001.json">RTL</button>
+        <button class="testFixture" data-json="http://bluemountain.princeton.edu/exist/restxq/iiif/collection/top">Collection</button>
+    </div>
+
+    <div class="metadataGroupOrder">
+      <ol>
+        <li>canvas</li>
+        <li>range</li>
+        <li>sequence</li>
+        <li>manifest</li>
+      </ol>
+      <button class="reverseGroups">Reverse</button>
+   </div>
+
     <div id="metadata" class="iiif-metadata-component">
-        loading...
     </div>
 
     <script>
 
         var helper, component;
-        
-        $(function() {
-            
-            // http://wellcomelibrary.org/iiif/b18035978/manifest (Biocrats)
-            // https://iiif.riksarkivet.se/arkis!C0000263/manifest (canvas metadata)
-            // https://iiif.riksarkivet.se/arkis!F0001185/manifest (merge source reference)
-            // https://edsilv.github.io/test-manifests/all-metadata.json (all metadata)
-            // http://tomcrane.github.io/scratch/manifests/vdc_100000004987.0x000001.json (rtl)
-            // http://bluemountain.princeton.edu/exist/restxq/iiif/collection/top
+
+        function loadManifest(manifest, groupOrder) {
 
             Manifold.loadManifest({
-                iiifResourceUri: 'http://wellcomelibrary.org/iiif/b18035978/manifest',
+                iiifResourceUri: manifest,
                 collectionIndex: 0,
                 manifestIndex: 0
             }).then(function(h){
-                
+
                 helper = h;
-                
                 component = new IIIFComponents.MetadataComponent({
                     target: document.querySelector('#metadata'),
                     data: {
-                        canvasDisplayOrder: "attribution, title",
+                      canvasDisplayOrder: "attribution, title",
+                      metadataGroupOrder: groupOrder,
                         canvases: [helper.getCanvasByIndex(0), helper.getCanvasByIndex(1)],
                         canvasLabels: "Left page, Right page",
                         //canvasExclude: "attribution",
@@ -83,6 +93,21 @@
 
             }).catch(function(e) {
                 console.error(e);
+            });
+        };
+
+        $(function() {
+            $('.reverseGroups').click(function() {
+                var ul = $(".metadataGroupOrder").children("ol");
+                var groupOrder = $.makeArray(ul.children("li")).reverse();
+                ul.empty();
+
+              $.each(groupOrder, (i, v) => ul.append(v));
+            });
+            $('.testFixture').click(function() {
+                var ul = $(".metadataGroupOrder").children("ol");
+                var groupOrder = $.map($.makeArray(ul.children("li")), (val, i) => val.innerText).join(",");
+                loadManifest( $(this).data('json'), groupOrder );
             });
         });
 

--- a/src/IMetadataComponentData.ts
+++ b/src/IMetadataComponentData.ts
@@ -20,6 +20,7 @@ namespace IIIFComponents{
     export interface IMetadataComponentData {
         //aggregateValues: string;                        // csv of metadata items to merge into a single item
         canvasDisplayOrder: string;                     // csv of items to override display order
+        metadataGroupOrder: string;                     // csv of metadata group display order, e.g. "manifest,sequence,range,canvas"
         canvases: Manifesto.ICanvas[] | null;           // which canvases to include
         canvasExclude: string;                          // csv of items to exclude from canvas metadata display
         canvasLabels: string;                           // csv of labels to use for canvas groups

--- a/src/MetadataComponent.ts
+++ b/src/MetadataComponent.ts
@@ -63,6 +63,7 @@ namespace IIIFComponents {
                 aggregateValues: "",
                 canvases: null,
                 canvasDisplayOrder: "",
+                metadataGroupOrder: "",
                 canvasExclude: "",
                 canvasLabels: "",
                 content: <IMetadataComponentContent>{
@@ -118,21 +119,24 @@ namespace IIIFComponents {
 
             if (this.options.data.manifestDisplayOrder) {
                 const manifestGroup: MetadataGroup = this._getManifestGroup();
-                manifestGroup.items = this._sort(manifestGroup.items, this._readCSV(this.options.data.manifestDisplayOrder));
+                manifestGroup.items = this._sortItems(manifestGroup.items, this._readCSV(this.options.data.manifestDisplayOrder));
             }
 
             if (this.options.data.canvasDisplayOrder) {
                 const canvasGroups: MetadataGroup[] = this._getCanvasGroups();
 
                 $.each(canvasGroups, (index: number, canvasGroup: MetadataGroup) => {
-                    canvasGroup.items = this._sort(canvasGroup.items, this._readCSV(this.options.data.canvasDisplayOrder));
+                    canvasGroup.items = this._sortItems(canvasGroup.items, this._readCSV(this.options.data.canvasDisplayOrder));
                 });
+            }
+            if (this.options.data.metadataGroupOrder) {
+                this._metadataGroups = this._sortGroups(this._metadataGroups, this._readCSV(this.options.data.metadataGroupOrder));
             }
 
             if (this.options.data.canvasLabels) {
                 this._label(this._getCanvasGroups(), this._readCSV(this.options.data.canvasLabels, false));
             }
-            
+
             if (this.options.data.manifestExclude) {
                 const manifestGroup: MetadataGroup = this._getManifestGroup();
                 manifestGroup.items = this._exclude(manifestGroup.items, this._readCSV(this.options.data.manifestExclude));
@@ -156,7 +160,7 @@ namespace IIIFComponents {
             this._render();
         }
 
-        private _sort(items: MetadataItem[], displayOrder: csvvalue[]): MetadataItem[] {
+        private _sortItems(items: MetadataItem[], displayOrder: csvvalue[]): MetadataItem[] {
 
             let sorted: MetadataItem[] = [];
             let unsorted: MetadataItem[] = items.clone();
@@ -174,6 +178,21 @@ namespace IIIFComponents {
                 sorted.push(item);
             });
 
+            return sorted;
+        }
+
+        private _sortGroups(groups: MetadataGroup[], metadataGroupOrder: csvvalue[]): MetadataGroup[] {
+
+            let sorted: MetadataGroup[] = [];
+            let unsorted: MetadataGroup[] = groups.clone();
+
+            $.each(metadataGroupOrder, (index: number, group: string) => {
+                const match: MetadataGroup = unsorted.en().where(x => x.resource.constructor.name.toLowerCase() == group).first();
+                if (match) {
+                    sorted.push(match);
+                    unsorted.remove(match);
+                }
+            });
             return sorted;
         }
 


### PR DESCRIPTION
new metadataGroupOrder option which takes csv, e.g.
"canvas,range,sequence,manifest" to control order of metadata groups, as proposed in issue #4 

examples page made to match that of the av-component