### PR TITLE
handle v3 rights

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export interface IMetadataComponentContent {
   more: string;
   noData: string;
   rangeHeader: string;
+  rights: string;
   sequenceHeader: string;
 }
 
@@ -147,6 +148,7 @@ export class MetadataComponent extends BaseComponent {
         more: "more",
         noData: "No data to display",
         rangeHeader: "About the range",
+        rights: "Rights",
         sequenceHeader: "About the sequence"
       },
       copiedMessageDuration: 2000,
@@ -512,7 +514,10 @@ export class MetadataComponent extends BaseComponent {
         case "logo":
           label = this._data.content.logo;
           break;
-      }
+        case "rights":
+          label = this._data.content.rights;
+          break;
+    }
     }
 
     label = this._sanitize(<string>label);
@@ -528,7 +533,7 @@ export class MetadataComponent extends BaseComponent {
     // if the value is a URI
     if (
       originalLabel &&
-      originalLabel.toLowerCase() === "license" &&
+      (originalLabel.toLowerCase() === "license" || originalLabel.toLowerCase() === "rights") &&
       urlPattern.exec(item.value[0].value) !== null
     ) {
       $value = this._buildMetadataItemURIValue(item.value[0].value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,12 @@ export interface IMetadataComponentContent {
   description: string;
   imageHeader: string;
   less: string;
+  lessAriaLabelPrefix;
   license: string;
   logo: string;
   manifestHeader: string;
   more: string;
+  moreAriaLabelPrefix: string;
   noData: string;
   rangeHeader: string;
   rights: string;
@@ -142,10 +144,12 @@ export class MetadataComponent extends BaseComponent {
         description: "Description",
         imageHeader: "About the image",
         less: "less",
+        lessAriaLabelPrefix: "Less information: Hide",
         license: "License",
         logo: "Logo",
         manifestHeader: "About the item",
         more: "more",
+        moreAriaLabelPrefix: "More information: Reveal",
         noData: "No data to display",
         rangeHeader: "About the range",
         rights: "Rights",
@@ -403,13 +407,18 @@ export class MetadataComponent extends BaseComponent {
         const $metadataGroup: JQuery = this._buildMetadataGroup(metadataGroup);
 				this._$metadataGroups.append($metadataGroup);
 				const $value: any = $metadataGroup.find(".value");
+        const $label: any = $metadataGroup.find(".label");
 
         if (this._data.limit && this._data.content) {
           if (this._data.limitType === LimitType.LINES) {
+            const lessAriaLabel: string = [this._data.content.lessAriaLabelPrefix, $label.html()].join(' ');
+            const moreAriaLabel: string = [this._data.content.moreAriaLabelPrefix, $label.html()].join(' ');
             $value.toggleExpandTextByLines(
                 this._data.limit,
                 this._data.content.less,
                 this._data.content.more,
+                lessAriaLabel,
+                moreAriaLabel,
                 () => {}
               );
           } else if (this._data.limitType === LimitType.CHARS) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export interface IMetadataComponentContent {
   description: string;
   imageHeader: string;
   less: string;
-  lessAriaLabelPrefix;
+  lessAriaLabelPrefix: string;
   license: string;
   logo: string;
   manifestHeader: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,18 +407,16 @@ export class MetadataComponent extends BaseComponent {
         const $metadataGroup: JQuery = this._buildMetadataGroup(metadataGroup);
 				this._$metadataGroups.append($metadataGroup);
 				const $value: any = $metadataGroup.find(".value");
-        const $label: any = $metadataGroup.find(".label");
+				const $items: any = $metadataGroup.find(".item");
 
         if (this._data.limit && this._data.content) {
           if (this._data.limitType === LimitType.LINES) {
-            const lessAriaLabel: string = [this._data.content.lessAriaLabelPrefix, $label.html()].join(' ');
-            const moreAriaLabel: string = [this._data.content.moreAriaLabelPrefix, $label.html()].join(' ');
-            $value.toggleExpandTextByLines(
+            $items.toggleExpandTextByLines(
                 this._data.limit,
                 this._data.content.less,
                 this._data.content.more,
-                lessAriaLabel,
-                moreAriaLabel,
+                this._data.content.lessAriaLabelPrefix,
+                this._data.content.moreAriaLabelPrefix,
                 () => {}
               );
           } else if (this._data.limitType === LimitType.CHARS) {


### PR DESCRIPTION
This PR relates to [issue 973](https://github.com/UniversalViewer/universalviewer/issues/973) in UV.

Rights, logo and requiredStatement changed with version 3 of the IIIF presentation API.

A new release of Manifesto was made to accommodate these ([commit here](https://github.com/IIIF-Commons/manifesto/commit/cb4beb1435269e666bf0df38f4d27d8a70ba3efd)]

And I've submitted a PR to Manifold to add the relevant items to the getMetadata function, [here](https://github.com/IIIF-Commons/manifold/pull/43)

This PR to iiif-metadata-component adds the option to define a label string for the rights, and to include it in the URI parsing so that rights URIs provided are rendered as links.


I've accidentally made commits to this PR related to [UV issue 1081](https://github.com/UniversalViewer/universalviewer/issues/1081). I can split them out to a new branch if necessary.