### PR TITLE
Handle v3 rights

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export interface IMetadataComponentContent {
   imageHeader: string;
   less: string;
   license: string;
+  rights: string;
   logo: string;
   manifestHeader: string;
   more: string;
@@ -142,6 +143,7 @@ export class MetadataComponent extends BaseComponent {
         imageHeader: "About the image",
         less: "less",
         license: "License",
+        rights: "Rights",
         logo: "Logo",
         manifestHeader: "About the item",
         more: "more",
@@ -512,6 +514,10 @@ export class MetadataComponent extends BaseComponent {
         case "logo":
           label = this._data.content.logo;
           break;
+        case "rights":
+          label = this._data.content.rights;
+          break;
+        }
       }
     }
 
@@ -528,7 +534,7 @@ export class MetadataComponent extends BaseComponent {
     // if the value is a URI
     if (
       originalLabel &&
-      originalLabel.toLowerCase() === "license" &&
+      (originalLabel.toLowerCase() === "license" || originalLabel.toLowerCase() === "rights") &&
       urlPattern.exec(item.value[0].value) !== null
     ) {
       $value = this._buildMetadataItemURIValue(item.value[0].value);


### PR DESCRIPTION
This PR relates to https://github.com/UniversalViewer/universalviewer/issues/973 in UV.

Rights, logo and requiredStatement changed with version 3 of the IIIF presentation API.

A new release of Manifesto was made to accommodate these ([commit here](https://github.com/IIIF-Commons/manifesto/commit/cb4beb1435269e666bf0df38f4d27d8a70ba3efd)]

And I've submitted a PR to Manifold to add the relevant items to the getMetadata function, https://github.com/IIIF-Commons/manifold/pull/43

This PR to iiif-metadata-component adds the option to define a label string for the rights, and to include it in the URI parsing so that rights URIs provided are rendered as links.
