### PR TITLE
Make nonclickable items not 'clickable' for screen readers (UV issue 1085)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -591,7 +591,6 @@ export class MetadataComponent extends BaseComponent {
       $metadataItem.on("click", "a.iiif-viewer-link", e => {
         e.preventDefault();
 
-        console.log(e)
         const $a: JQuery = $(e.target);
         const href: string = $a.attr('data-uv-navigate') || $a.prop('href');
 
@@ -602,7 +601,6 @@ export class MetadataComponent extends BaseComponent {
     if ($metadataItem.find('[data-uv-navigate]').length > 0) {
       $metadataItem.on('click', '[data-uv-navigate]', (e) => {
         e.preventDefault();
-        console.log(e)
 
         const $a: JQuery = $(e.target);
         const href: string | null = $a.attr('data-uv-navigate') || null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,24 +587,30 @@ export class MetadataComponent extends BaseComponent {
 
     const that = this;
 
-    $metadataItem.on("click", "a.iiif-viewer-link", e => {
-      e.preventDefault();
+    if ($metadataItem.find('a.iiif-viewer-link').length > 0) {
+      $metadataItem.on("click", "a.iiif-viewer-link", e => {
+        e.preventDefault();
 
-      const $a: JQuery = $(e.target);
-      const href: string = $a.attr('data-uv-navigate') || $a.prop('href');
+        console.log(e)
+        const $a: JQuery = $(e.target);
+        const href: string = $a.attr('data-uv-navigate') || $a.prop('href');
 
-      that.fire(Events.IIIF_VIEWER_LINK_CLICKED, href);
-    });
+        that.fire(Events.IIIF_VIEWER_LINK_CLICKED, href);
+      });
+    };
 
-    $metadataItem.on('click', '[data-uv-navigate]', (e) => {
-      e.preventDefault();
+    if ($metadataItem.find('[data-uv-navigate]').length > 0) {
+      $metadataItem.on('click', '[data-uv-navigate]', (e) => {
+        e.preventDefault();
+        console.log(e)
 
-      const $a: JQuery = $(e.target);
-      const href: string | null = $a.attr('data-uv-navigate') || null;
-      if (href) {
-          that.fire(Events.IIIF_VIEWER_LINK_CLICKED, href);
-      }
-    });
+        const $a: JQuery = $(e.target);
+        const href: string | null = $a.attr('data-uv-navigate') || null;
+        if (href) {
+            that.fire(Events.IIIF_VIEWER_LINK_CLICKED, href);
+        }
+      });
+    };
 
     return $metadataItem;
   }


### PR DESCRIPTION
This should resolve one of the problems in [UV issue 1085](https://github.com/UniversalViewer/universalviewer/issues/1085), where metadata items in the right panel are identified as 'clickable' by screen readers because they have an on-click event listener.

This PR assigns the event-listeners conditionally to items with the desired content. This is so metadata related to navigation around AV content is rendered as timecode links (see this old closed issue for examples: https://github.com/UniversalViewer/universalviewer/issues/849). The other scenario is a iiif-viewer-link, related to changing the range currently in view.

NB metadata items will still appear with event listeners in dev tools – these are mousein/out events to activate the copy buttons