### PR TITLE
Use installed node_modules instead of CDN where possible.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,11 +8,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsviews/0.9.75/jsviews.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.min.js"></script>
-    <script src="https://unpkg.com/manifesto.js@4.0.1/dist-umd/manifesto.js"></script>
-    <script src="https://unpkg.com/@iiif/manifold@2.0.2/dist-umd/manifold.js"></script>
     <script src="https://unpkg.com/xss@1.0.3/dist/xss.js"></script>
-    <script src="https://unpkg.com/@edsilv/utils@1.0.2/dist-umd/utils.js"></script>
-    <script src="https://unpkg.com/@edsilv/jquery-plugins@1.0.7/dist/jquery-plugins.js"></script>
+    <script src="/node_modules/manifesto.js/dist-umd/manifesto.js"></script>
+    <script src="/node_modules/@iiif/manifold/dist-umd/manifold.js"></script>
+    <script src="/node_modules/@edsilv/utils/dist-umd/utils.js"></script>
+    <script src="/node_modules/@edsilv/jquery-plugins/dist/jquery-plugins.js"></script>
     <script src="../dist-umd/IIIFMetadataComponent.js"></script>
     <style type="text/css">
         .options div {


### PR DESCRIPTION
Using hard-coded versions of components via CDNs instead of the actual versions used to compile the component could potentially lead to strange bugs. This PR uses the available versions in the example page for more consistent behavior.